### PR TITLE
Fix mobile header layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ import { SignedIn, SignedOut, UserButton } from "@clerk/astro/components";
     <header
       class="w-full bg-white/25 border-b border-slate-200/25 sticky top-0 z-[100] h-[73px] flex items-center justify-center"
     >
-      <div class="grid grid-cols-3 items-center px-6 w-full max-w-7xl">
+      <div class="grid grid-cols-2 md:grid-cols-3 items-center px-6 w-full max-w-7xl">
         <a href="/" class="flex items-center gap-3 group justify-self-start">
           <div
             class="w-9 h-9 rounded-full bg-gradient-to-tr from-slate-900 via-gray-600 to-zinc-700 flex items-center justify-center text-white font-bold shadow-lg shadow-indigo-500/30 group-hover:scale-105 transition-transform duration-300"
@@ -72,12 +72,12 @@ import { SignedIn, SignedOut, UserButton } from "@clerk/astro/components";
           <SignedOut>
             <a
               href="/login"
-              class="text-sm font-semibold text-slate-600 hover:text-blue-600 px-3 py-2 transition-colors"
+              class="text-sm font-semibold text-slate-600 hover:text-blue-600 px-3 py-2 transition-colors whitespace-nowrap"
               >Log in</a
             >
             <a
               href="/register"
-              class="text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-500 hover:to-cyan-500 px-5 py-2 rounded-full transition-all shadow-md shadow-blue-500/25 active:scale-95"
+              class="text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-500 hover:to-cyan-500 px-5 py-2 rounded-full transition-all shadow-md shadow-blue-500/25 active:scale-95 whitespace-nowrap"
               >Get Started</a
             >
           </SignedOut>


### PR DESCRIPTION
## Problem

On mobile, the header in `src/layouts/Layout.astro` renders incorrectly:

- "Log in" overlaps the "Stratos" wordmark
- "Get Started" wraps onto two lines

## Root cause

The header container uses `grid grid-cols-3` at all breakpoints:

```astro